### PR TITLE
Feature/file occurrences across prs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build
 /*.properties
 /*.tsv
 /*.svg
+/*.csv

--- a/bucketlist/src/main/kotlin/io/aexp/bucketlist/BucketListClient.kt
+++ b/bucketlist/src/main/kotlin/io/aexp/bucketlist/BucketListClient.kt
@@ -35,9 +35,14 @@ interface BucketListClient {
             Observable<PagedResponse<PullRequestCommit>>
 
     /**
+     * @param contextLines "the number of context lines to include around added/removed lines in the diff"
+     * @param whitespace "optional whitespace flag which can be set to 'ignore-all'" Default value is "show"
+     * @param withComments "true to embed comments in the diff (the default); otherwise, false to stream the diff without comments"
+     * Param descriptions from official Atlassian documentation for Stash REST API
+     *
      * @return observable of PR diff response
      */
-    fun getPrDiff(projectKey: String, repoSlug: String, prId: Long, contextLines: Int, whitespace: Boolean,
+    fun getPrDiff(projectKey: String, repoSlug: String, prId: Long, contextLines: Int, whitespace: String,
                   withComments: Boolean): Observable<PullRequestDiffResponse>
 
     /**

--- a/bucketlist/src/main/kotlin/io/aexp/bucketlist/BucketListClient.kt
+++ b/bucketlist/src/main/kotlin/io/aexp/bucketlist/BucketListClient.kt
@@ -37,13 +37,13 @@ interface BucketListClient {
 
     /**
      * @param contextLines "the number of context lines to include around added/removed lines in the diff"
-     * @param whitespace "optional whitespace flag which can be set to 'ignore-all'" Default value is "show"
+     * @param whitespaceMode whether to show or ignore all whitespace changes as part of diff response
      * @param commentMode whether to include comments as part of diff response
      * Param descriptions from official Atlassian documentation for Stash REST API
      *
      * @return observable that emits a single PullRequestDiffResponse
      */
-    fun getPrDiff(projectKey: String, repoSlug: String, prId: Long, contextLines: Int, whitespace: String,
+    fun getPrDiff(projectKey: String, repoSlug: String, prId: Long, contextLines: Int, whitespaceMode: WhitespaceMode,
                   commentMode: CommentMode): Observable<PullRequestDiffResponse>
 
     /**

--- a/bucketlist/src/main/kotlin/io/aexp/bucketlist/BucketListClient.kt
+++ b/bucketlist/src/main/kotlin/io/aexp/bucketlist/BucketListClient.kt
@@ -6,8 +6,8 @@ import io.aexp.bucketlist.data.PagedResponse
 import io.aexp.bucketlist.data.PullRequest
 import io.aexp.bucketlist.data.PullRequestActivity
 import io.aexp.bucketlist.data.PullRequestCommit
-import io.aexp.bucketlist.data.PullRequestState
 import io.aexp.bucketlist.data.PullRequestDiffResponse
+import io.aexp.bucketlist.data.PullRequestState
 import rx.Observable
 
 interface BucketListClient {

--- a/bucketlist/src/main/kotlin/io/aexp/bucketlist/BucketListClient.kt
+++ b/bucketlist/src/main/kotlin/io/aexp/bucketlist/BucketListClient.kt
@@ -1,5 +1,6 @@
 package io.aexp.bucketlist
 
+import io.aexp.bucketlist.data.CommentMode
 import io.aexp.bucketlist.data.Order
 import io.aexp.bucketlist.data.PagedResponse
 import io.aexp.bucketlist.data.PullRequest
@@ -37,13 +38,13 @@ interface BucketListClient {
     /**
      * @param contextLines "the number of context lines to include around added/removed lines in the diff"
      * @param whitespace "optional whitespace flag which can be set to 'ignore-all'" Default value is "show"
-     * @param withComments "true to embed comments in the diff (the default); otherwise, false to stream the diff without comments"
+     * @param commentMode whether to include comments as part of diff response
      * Param descriptions from official Atlassian documentation for Stash REST API
      *
      * @return observable that emits a single PullRequestDiffResponse
      */
     fun getPrDiff(projectKey: String, repoSlug: String, prId: Long, contextLines: Int, whitespace: String,
-                  withComments: Boolean): Observable<PullRequestDiffResponse>
+                  commentMode: CommentMode): Observable<PullRequestDiffResponse>
 
     /**
      * @param fromId the commit or treeish that is the source of the PR, e.g. "refs/heads/some-new-branch"

--- a/bucketlist/src/main/kotlin/io/aexp/bucketlist/BucketListClient.kt
+++ b/bucketlist/src/main/kotlin/io/aexp/bucketlist/BucketListClient.kt
@@ -40,7 +40,7 @@ interface BucketListClient {
      * @param withComments "true to embed comments in the diff (the default); otherwise, false to stream the diff without comments"
      * Param descriptions from official Atlassian documentation for Stash REST API
      *
-     * @return observable of PR diff response
+     * @return observable that emits a single PullRequestDiffResponse
      */
     fun getPrDiff(projectKey: String, repoSlug: String, prId: Long, contextLines: Int, whitespace: String,
                   withComments: Boolean): Observable<PullRequestDiffResponse>

--- a/bucketlist/src/main/kotlin/io/aexp/bucketlist/BucketListClient.kt
+++ b/bucketlist/src/main/kotlin/io/aexp/bucketlist/BucketListClient.kt
@@ -36,7 +36,7 @@ interface BucketListClient {
             Observable<PagedResponse<PullRequestCommit>>
 
     /**
-     * @param contextLines "the number of context lines to include around added/removed lines in the diff"
+     * @param contextLines the number of lines of context to include around added/removed/modified lines in this diff
      * @param whitespaceMode whether to show or ignore all whitespace changes as part of diff response
      * @param commentMode whether to include comments as part of diff response
      * Param descriptions from official Atlassian documentation for Stash REST API

--- a/bucketlist/src/main/kotlin/io/aexp/bucketlist/BucketListClient.kt
+++ b/bucketlist/src/main/kotlin/io/aexp/bucketlist/BucketListClient.kt
@@ -6,6 +6,7 @@ import io.aexp.bucketlist.data.PullRequest
 import io.aexp.bucketlist.data.PullRequestActivity
 import io.aexp.bucketlist.data.PullRequestCommit
 import io.aexp.bucketlist.data.PullRequestState
+import io.aexp.bucketlist.data.PullRequestDiffResponse
 import rx.Observable
 
 interface BucketListClient {
@@ -32,6 +33,12 @@ interface BucketListClient {
      */
     fun getPrCommits(projectKey: String, repoSlug: String, prId: Long):
             Observable<PagedResponse<PullRequestCommit>>
+
+    /**
+     * @return observable of PR diff response
+     */
+    fun getPrDiff(projectKey: String, repoSlug: String, prId: Long, contextLines: Int, whitespace: Boolean,
+                  withComments: Boolean): Observable<PullRequestDiffResponse>
 
     /**
      * @param fromId the commit or treeish that is the source of the PR, e.g. "refs/heads/some-new-branch"

--- a/bucketlist/src/main/kotlin/io/aexp/bucketlist/HttpBucketListClient.kt
+++ b/bucketlist/src/main/kotlin/io/aexp/bucketlist/HttpBucketListClient.kt
@@ -79,15 +79,15 @@ class HttpBucketListClient(private val baseUrl: URL,
         return subject;
     }
 
-    override fun getPrDiff(projectKey: String, repoSlug: String, prId: Long, contextLines: Int, whitespace: String,
-                           commentMode: CommentMode): Observable<PullRequestDiffResponse> {
+    override fun getPrDiff(projectKey: String, repoSlug: String, prId: Long, contextLines: Int, whitespaceMode:
+        WhitespaceMode, commentMode: CommentMode): Observable<PullRequestDiffResponse> {
         val subject: Subject<PullRequestDiffResponse, PullRequestDiffResponse> = ReplaySubject.create()
 
         val urlBuilder = UrlBuilder.fromUrl(baseUrl)
                 .pathSegments("rest", "api", "1.0", "projects", projectKey, "repos", repoSlug, "pull-requests",
                         prId.toString(), "diff")
                 .queryParam("contextLines", contextLines.toString())
-                .queryParam("whitespace", whitespace)
+                .queryParam("whitespace", getDiffAPIWhitespaceModeValue(whitespaceMode))
                 .queryParam("withComments", getDiffAPICommentModeValue(commentMode))
 
         addAuth(httpClient.prepareGet(urlBuilder.toUrlString()))

--- a/bucketlist/src/main/kotlin/io/aexp/bucketlist/HttpBucketListClient.kt
+++ b/bucketlist/src/main/kotlin/io/aexp/bucketlist/HttpBucketListClient.kt
@@ -105,15 +105,15 @@ class HttpBucketListClient(private val baseUrl: URL,
 
     private fun getDiffAPICommentModeValue(commentMode: CommentMode): String {
         when(commentMode) {
-            CommentMode.WithComments -> return "true"
-            CommentMode.WithoutComments -> return "false"
+            CommentMode.WITH_COMMENTS -> return "true"
+            CommentMode.WITHOUT_COMMENTS -> return "false"
         }
     }
 
     private fun getDiffAPIWhitespaceModeValue(whitespaceMode: WhitespaceMode): String {
         when(whitespaceMode) {
-            WhitespaceMode.Show -> return "show"
-            WhitespaceMode.IgnoreAll -> return "ignore-all"
+            WhitespaceMode.SHOW -> return "show"
+            WhitespaceMode.IGNORE_ALL -> return "ignore-all"
         }
     }
 

--- a/bucketlist/src/main/kotlin/io/aexp/bucketlist/HttpBucketListClient.kt
+++ b/bucketlist/src/main/kotlin/io/aexp/bucketlist/HttpBucketListClient.kt
@@ -78,7 +78,7 @@ class HttpBucketListClient(private val baseUrl: URL,
         return subject;
     }
 
-    override fun getPrDiff(projectKey: String, repoSlug: String, prId: Long, contextLines: Int, whitespace: Boolean,
+    override fun getPrDiff(projectKey: String, repoSlug: String, prId: Long, contextLines: Int, whitespace: String,
                            withComments: Boolean): Observable<PullRequestDiffResponse> {
         val subject: Subject<PullRequestDiffResponse, PullRequestDiffResponse> = ReplaySubject.create()
 
@@ -86,7 +86,7 @@ class HttpBucketListClient(private val baseUrl: URL,
                 .pathSegments("rest", "api", "1.0", "projects", projectKey, "repos", repoSlug, "pull-requests",
                         prId.toString(), "diff")
                 .queryParam("contextLines", contextLines.toString())
-                .queryParam("whitespace", whitespace.toString())
+                .queryParam("whitespace", whitespace)
                 .queryParam("withComments", withComments.toString())
 
         addAuth(httpClient.prepareGet(urlBuilder.toUrlString()))

--- a/bucketlist/src/main/kotlin/io/aexp/bucketlist/WhitespaceMode.kt
+++ b/bucketlist/src/main/kotlin/io/aexp/bucketlist/WhitespaceMode.kt
@@ -1,0 +1,9 @@
+package io.aexp.bucketlist
+
+
+enum class WhitespaceMode {
+    Show,
+    IgnoreAll
+}
+
+

--- a/bucketlist/src/main/kotlin/io/aexp/bucketlist/WhitespaceMode.kt
+++ b/bucketlist/src/main/kotlin/io/aexp/bucketlist/WhitespaceMode.kt
@@ -2,8 +2,8 @@ package io.aexp.bucketlist
 
 
 enum class WhitespaceMode {
-    Show,
-    IgnoreAll
+    SHOW,
+    IGNORE_ALL
 }
 
 

--- a/bucketlist/src/main/kotlin/io/aexp/bucketlist/data/CommentMode.kt
+++ b/bucketlist/src/main/kotlin/io/aexp/bucketlist/data/CommentMode.kt
@@ -1,0 +1,7 @@
+package io.aexp.bucketlist.data
+
+
+enum class CommentMode {
+    WithComments,
+    WithoutComments
+}

--- a/bucketlist/src/main/kotlin/io/aexp/bucketlist/data/CommentMode.kt
+++ b/bucketlist/src/main/kotlin/io/aexp/bucketlist/data/CommentMode.kt
@@ -2,6 +2,6 @@ package io.aexp.bucketlist.data
 
 
 enum class CommentMode {
-    WithComments,
-    WithoutComments
+    WITH_COMMENTS,
+    WITHOUT_COMMENTS
 }

--- a/bucketlist/src/main/kotlin/io/aexp/bucketlist/data/PullRequest.kt
+++ b/bucketlist/src/main/kotlin/io/aexp/bucketlist/data/PullRequest.kt
@@ -8,6 +8,8 @@ import java.util.Date
 class PullRequest(@JsonProperty("id") val id: Long,
                   @JsonProperty("author") val author: PullRequestAuthor,
                   @JsonProperty("closed") val closed: Boolean,
+                  @JsonProperty("fromRef") val fromRef: PullRequestRef,
+                  @JsonProperty("toRef") val toRef: PullRequestRef,
                   private @JsonProperty("createdDate") val createdDate: Date,
                   private @JsonProperty("updatedDate") val updatedDate: Date) {
 

--- a/bucketlist/src/main/kotlin/io/aexp/bucketlist/data/PullRequestDiff.kt
+++ b/bucketlist/src/main/kotlin/io/aexp/bucketlist/data/PullRequestDiff.kt
@@ -2,6 +2,14 @@ package io.aexp.bucketlist.data
 
 import com.fasterxml.jackson.annotation.JsonProperty
 
+/**
+ * The diff for a single file within a pull request
+ * @param source the path for the file prior to the changes. Can be Null if the file was created as part of this diff
+ * @param destination the path for the file after the changes. Can be Null if the file was deleted as part of this diff
+ * @param hunks list of changes made within this file, broken up into hunks based on line proximity grouping. Null if no
+ *              code was changed as part of this diff (e.g. file renamed without modification)
+ * @param truncated boolean indicating if response size limits resulted in the hunks in this diff getting truncated
+ */
 class PullRequestDiff(@JsonProperty("source") val source: PullRequestFilePath?,
                       @JsonProperty("destination") val destination: PullRequestFilePath?,
                       @JsonProperty("hunks") val hunks: List<PullRequestHunk>?,

--- a/bucketlist/src/main/kotlin/io/aexp/bucketlist/data/PullRequestDiff.kt
+++ b/bucketlist/src/main/kotlin/io/aexp/bucketlist/data/PullRequestDiff.kt
@@ -1,0 +1,8 @@
+package io.aexp.bucketlist.data
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+class PullRequestDiff(@JsonProperty("source") val source: PullRequestFilePath?,
+                      @JsonProperty("destination") val destination: PullRequestFilePath?,
+                      @JsonProperty("hunks") val hunks: List<PullRequestHunk>?,
+                      @JsonProperty("truncated") val truncated: Boolean)

--- a/bucketlist/src/main/kotlin/io/aexp/bucketlist/data/PullRequestDiffResponse.kt
+++ b/bucketlist/src/main/kotlin/io/aexp/bucketlist/data/PullRequestDiffResponse.kt
@@ -1,0 +1,7 @@
+package io.aexp.bucketlist.data
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+class PullRequestDiffResponse(@JsonProperty("fromHash") val fromHash: String,
+                              @JsonProperty("toHash") val toHash: String,
+                              @JsonProperty("diffs") val diffs: List<PullRequestDiff>)

--- a/bucketlist/src/main/kotlin/io/aexp/bucketlist/data/PullRequestFilePath.kt
+++ b/bucketlist/src/main/kotlin/io/aexp/bucketlist/data/PullRequestFilePath.kt
@@ -1,0 +1,7 @@
+package io.aexp.bucketlist.data
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+class PullRequestFilePath(@JsonProperty("components") val components: List<String>,
+                          @JsonProperty("name") val name: String,
+                          @JsonProperty("toString") val fullPath: String)

--- a/bucketlist/src/main/kotlin/io/aexp/bucketlist/data/PullRequestHunk.kt
+++ b/bucketlist/src/main/kotlin/io/aexp/bucketlist/data/PullRequestHunk.kt
@@ -1,0 +1,8 @@
+package io.aexp.bucketlist.data
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+class PullRequestHunk(@JsonProperty("sourceLine") val sourceLine: Int,
+                      @JsonProperty("sourceSpan") val sourceSpan: Int,
+                      @JsonProperty("destinationLine") val destinationLine: Int,
+                      @JsonProperty("destinationSpan") val destinationSpan: Int)

--- a/bucketlist/src/main/kotlin/io/aexp/bucketlist/data/PullRequestRef.kt
+++ b/bucketlist/src/main/kotlin/io/aexp/bucketlist/data/PullRequestRef.kt
@@ -1,0 +1,5 @@
+package io.aexp.bucketlist.data
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+class PullRequestRef(@JsonProperty("id") val id:String)

--- a/bucketlist/src/test/java/io/aexp/bucketlist/HttpBucketListClientTest.java
+++ b/bucketlist/src/test/java/io/aexp/bucketlist/HttpBucketListClientTest.java
@@ -16,7 +16,6 @@ import io.aexp.bucketlist.data.PullRequestDiff;
 import io.aexp.bucketlist.data.PullRequestDiffResponse;
 import io.aexp.bucketlist.data.PullRequestHunk;
 import io.aexp.bucketlist.data.PullRequestState;
-
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -24,7 +23,6 @@ import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.junit.Before;

--- a/bucketlist/src/test/java/io/aexp/bucketlist/HttpBucketListClientTest.java
+++ b/bucketlist/src/test/java/io/aexp/bucketlist/HttpBucketListClientTest.java
@@ -188,7 +188,7 @@ public class HttpBucketListClientTest {
     public void testGetPrDiff() throws IOException {
         Map<String, Object> params = new HashMap();
         params.put("contextLines", "0");
-        params.put("whitespace", "false");
+        params.put("whitespace", "ignore-all");
         params.put("withComments", "false");
 
         driver.addExpectation(
@@ -197,7 +197,7 @@ public class HttpBucketListClientTest {
                 giveResponse(Resources.toString(getResource(getClass(), "getPrDiffResp.json"), UTF_8),
                         "application/json"));
 
-        PullRequestDiffResponse diffResponse = client.getPrDiff(proj, repo, 2, 0, false, false)
+        PullRequestDiffResponse diffResponse = client.getPrDiff(proj, repo, 2, 0, "ignore-all", false)
                 .toBlocking()
                 .first();
 

--- a/bucketlist/src/test/java/io/aexp/bucketlist/HttpBucketListClientTest.java
+++ b/bucketlist/src/test/java/io/aexp/bucketlist/HttpBucketListClientTest.java
@@ -7,6 +7,7 @@ import com.github.restdriver.clientdriver.ClientDriverRule;
 import com.google.common.io.Resources;
 import com.ning.http.client.AsyncHttpClient;
 import io.aexp.bucketlist.auth.Authenticator;
+import io.aexp.bucketlist.data.CommentMode;
 import io.aexp.bucketlist.data.Order;
 import io.aexp.bucketlist.data.PagedResponse;
 import io.aexp.bucketlist.data.PullRequest;
@@ -195,7 +196,7 @@ public class HttpBucketListClientTest {
                 giveResponse(Resources.toString(getResource(getClass(), "getPrDiffResp.json"), UTF_8),
                         "application/json"));
 
-        PullRequestDiffResponse diffResponse = client.getPrDiff(proj, repo, 2, 0, "ignore-all", false)
+        PullRequestDiffResponse diffResponse = client.getPrDiff(proj, repo, 2, 0, "ignore-all", CommentMode.WithoutComments)
                 .toBlocking()
                 .first();
 

--- a/bucketlist/src/test/java/io/aexp/bucketlist/HttpBucketListClientTest.java
+++ b/bucketlist/src/test/java/io/aexp/bucketlist/HttpBucketListClientTest.java
@@ -196,7 +196,7 @@ public class HttpBucketListClientTest {
                 giveResponse(Resources.toString(getResource(getClass(), "getPrDiffResp.json"), UTF_8),
                         "application/json"));
 
-        PullRequestDiffResponse diffResponse = client.getPrDiff(proj, repo, 2, 0, "ignore-all", CommentMode.WithoutComments)
+        PullRequestDiffResponse diffResponse = client.getPrDiff(proj, repo, 2, 0, WhitespaceMode.IgnoreAll, CommentMode.WithoutComments)
                 .toBlocking()
                 .first();
 

--- a/bucketlist/src/test/java/io/aexp/bucketlist/HttpBucketListClientTest.java
+++ b/bucketlist/src/test/java/io/aexp/bucketlist/HttpBucketListClientTest.java
@@ -12,12 +12,18 @@ import io.aexp.bucketlist.data.PagedResponse;
 import io.aexp.bucketlist.data.PullRequest;
 import io.aexp.bucketlist.data.PullRequestActivity;
 import io.aexp.bucketlist.data.PullRequestCommit;
+import io.aexp.bucketlist.data.PullRequestDiff;
+import io.aexp.bucketlist.data.PullRequestDiffResponse;
+import io.aexp.bucketlist.data.PullRequestHunk;
 import io.aexp.bucketlist.data.PullRequestState;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.time.ZonedDateTime;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.junit.Before;
@@ -175,6 +181,40 @@ public class HttpBucketListClientTest {
         PullRequestCommit commit2 = page.getValues().get(1);
         assertEquals("commit id 2", commit2.getId());
         assertEquals("Jane", commit2.getAuthor().getName());
+    }
+
+    @Test
+    public void testGetPrDiff() throws IOException {
+        Map<String,Object> params = new HashMap();
+        params.put("contextLines","0");
+        params.put("whitespace","false");
+        params.put("withComments","false");
+
+        driver.addExpectation(
+                onRequestTo("/rest/api/1.0/projects/" + proj + "/repos/" + repo + "/pull-requests/2/diff")
+                .withParams(params),
+                giveResponse(Resources.toString(getResource(getClass(), "getPrDiffResp.json"), UTF_8),
+                        "application/json"));
+
+        PullRequestDiffResponse diffResponse = client.getPrDiff(proj, repo, 2, 0, false, false)
+                .toBlocking()
+                .first();
+
+        assertEquals("16fb16e8afbe6c4087d39feddd68bdc881e302a2",diffResponse.getFromHash());
+        assertEquals("1830d0529a30d3d7253935d918ee0e34e7680c64",diffResponse.getToHash());
+        assertEquals(2, diffResponse.getDiffs().size());
+
+        PullRequestDiff secondDiff = diffResponse.getDiffs().get(1);
+        assertEquals(null, secondDiff.getSource());
+        assertEquals("Tests/Controllers/MyAwesomeControllerTests.swift", secondDiff.getDestination().getFullPath());
+        assertFalse(secondDiff.getTruncated());
+        assertEquals(2, secondDiff.getHunks().size());
+
+        PullRequestHunk firstHunk = secondDiff.getHunks().get(0);
+        assertEquals(0, firstHunk.getSourceLine());
+        assertEquals(0, firstHunk.getSourceSpan());
+        assertEquals(1, firstHunk.getDestinationLine());
+        assertEquals(46, firstHunk.getDestinationSpan());
     }
 
     @Test

--- a/bucketlist/src/test/java/io/aexp/bucketlist/HttpBucketListClientTest.java
+++ b/bucketlist/src/test/java/io/aexp/bucketlist/HttpBucketListClientTest.java
@@ -196,7 +196,7 @@ public class HttpBucketListClientTest {
                 giveResponse(Resources.toString(getResource(getClass(), "getPrDiffResp.json"), UTF_8),
                         "application/json"));
 
-        PullRequestDiffResponse diffResponse = client.getPrDiff(proj, repo, 2, 0, WhitespaceMode.IgnoreAll, CommentMode.WithoutComments)
+        PullRequestDiffResponse diffResponse = client.getPrDiff(proj, repo, 2, 0, WhitespaceMode.IGNORE_ALL, CommentMode.WITHOUT_COMMENTS)
                 .toBlocking()
                 .first();
 

--- a/bucketlist/src/test/java/io/aexp/bucketlist/HttpBucketListClientTest.java
+++ b/bucketlist/src/test/java/io/aexp/bucketlist/HttpBucketListClientTest.java
@@ -16,6 +16,7 @@ import io.aexp.bucketlist.data.PullRequestDiff;
 import io.aexp.bucketlist.data.PullRequestDiffResponse;
 import io.aexp.bucketlist.data.PullRequestHunk;
 import io.aexp.bucketlist.data.PullRequestState;
+
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -185,14 +186,14 @@ public class HttpBucketListClientTest {
 
     @Test
     public void testGetPrDiff() throws IOException {
-        Map<String,Object> params = new HashMap();
-        params.put("contextLines","0");
-        params.put("whitespace","false");
-        params.put("withComments","false");
+        Map<String, Object> params = new HashMap();
+        params.put("contextLines", "0");
+        params.put("whitespace", "false");
+        params.put("withComments", "false");
 
         driver.addExpectation(
                 onRequestTo("/rest/api/1.0/projects/" + proj + "/repos/" + repo + "/pull-requests/2/diff")
-                .withParams(params),
+                        .withParams(params),
                 giveResponse(Resources.toString(getResource(getClass(), "getPrDiffResp.json"), UTF_8),
                         "application/json"));
 
@@ -200,8 +201,8 @@ public class HttpBucketListClientTest {
                 .toBlocking()
                 .first();
 
-        assertEquals("16fb16e8afbe6c4087d39feddd68bdc881e302a2",diffResponse.getFromHash());
-        assertEquals("1830d0529a30d3d7253935d918ee0e34e7680c64",diffResponse.getToHash());
+        assertEquals("16fb16e8afbe6c4087d39feddd68bdc881e302a2", diffResponse.getFromHash());
+        assertEquals("1830d0529a30d3d7253935d918ee0e34e7680c64", diffResponse.getToHash());
         assertEquals(2, diffResponse.getDiffs().size());
 
         PullRequestDiff secondDiff = diffResponse.getDiffs().get(1);

--- a/bucketlist/src/test/resources/io/aexp/bucketlist/getPrDiffResp.json
+++ b/bucketlist/src/test/resources/io/aexp/bucketlist/getPrDiffResp.json
@@ -1,0 +1,139 @@
+{
+  "fromHash": "16fb16e8afbe6c4087d39feddd68bdc881e302a2",
+  "toHash": "1830d0529a30d3d7253935d918ee0e34e7680c64",
+  "contextLines": 0,
+  "whitespace": "SHOW",
+  "diffs": [
+    {
+      "source": {
+        "components": [
+          "Directory",
+          "Controllers",
+          "MyAwesomeController.m"
+        ],
+        "parent": "Directory/Controllers",
+        "name": "MyAwesomeController.m",
+        "extension": "m",
+        "toString": "Directory/Controllers/MyAwesomeController.m"
+      },
+      "destination": {
+        "components": [
+          "Directory",
+          "Controllers",
+          "MyAwesomeController.m"
+        ],
+        "parent": "Directory/Controllers",
+        "name": "MyAwesomeController.m",
+        "extension": "m",
+        "toString": "Directory/Controllers/MyAwesomeController.m"
+      },
+      "hunks": [
+        {
+          "sourceLine": 143,
+          "sourceSpan": 1,
+          "destinationLine": 143,
+          "destinationSpan": 1,
+          "segments": [
+            {
+              "type": "REMOVED",
+              "lines": [
+                {
+                  "source": 143,
+                  "destination": 143,
+                  "line": "  UIAlertController *alertController = [UIAlertController alertControllerWithTitle:NSLocalizedString(@\"CANCEL_BUTTON\", nil)",
+                  "truncated": false
+                }
+              ],
+              "truncated": false
+            },
+            {
+              "type": "ADDED",
+              "lines": [
+                {
+                  "source": 144,
+                  "destination": 143,
+                  "line": "  UIAlertController *alertController = [UIAlertController alertControllerWithTitle:nil",
+                  "truncated": false
+                }
+              ],
+              "truncated": false
+            }
+          ],
+          "truncated": false
+        }
+      ],
+      "truncated": false
+    },
+    {
+      "source": null,
+      "destination": {
+        "components": [
+          "Tests",
+          "Controllers",
+          "MyAwesomeControllerTests.swift"
+        ],
+        "parent": "Tests/Controllers",
+        "name": "MyAwesomeControllerTests.swift",
+        "extension": "swift",
+        "toString": "Tests/Controllers/MyAwesomeControllerTests.swift"
+      },
+      "hunks": [
+        {
+          "sourceLine": 0,
+          "sourceSpan": 0,
+          "destinationLine": 1,
+          "destinationSpan": 46,
+          "segments": [
+            {
+              "type": "ADDED",
+              "lines": [
+                {
+                  "source": 0,
+                  "destination": 1,
+                  "line": "import XCTest",
+                  "truncated": false
+                },
+                {
+                  "source": 0,
+                  "destination": 2,
+                  "line": "@testable import MyProject",
+                  "truncated": false
+                }
+              ],
+              "truncated": false
+            }
+          ],
+          "truncated": false
+        },
+        {
+          "sourceLine": 0,
+          "sourceSpan": 0,
+          "destinationLine": 1,
+          "destinationSpan": 46,
+          "segments": [
+            {
+              "type": "ADDED",
+              "lines": [
+                {
+                  "source": 0,
+                  "destination": 1,
+                  "line": "import XCTest",
+                  "truncated": false
+                },
+                {
+                  "source": 0,
+                  "destination": 2,
+                  "line": "@testable import MyProject",
+                  "truncated": false
+                }
+              ],
+              "truncated": false
+            }
+          ],
+          "truncated": false
+        }
+      ],
+      "truncated": false
+    }
+  ]
+}

--- a/examples/src/main/kotlin/io/aexp/bucketlist/examples/Helpers.kt
+++ b/examples/src/main/kotlin/io/aexp/bucketlist/examples/Helpers.kt
@@ -22,7 +22,7 @@ import java.util.Properties
  * This means that you never have to put the password in a shell command, so it can stay out of your shell history,
  * process listing, etc.
  */
-fun getBitBucketClient(configPath: Path): BucketListClient {
+fun getBitBucketClient(configPath: Path, asyncHttpClient: AsyncHttpClient = AsyncHttpClient()): BucketListClient {
     val props = Properties()
     props.load(Files.newBufferedReader(configPath, StandardCharsets.UTF_8))
 
@@ -35,7 +35,7 @@ fun getBitBucketClient(configPath: Path): BucketListClient {
 
     return HttpBucketListClient(url,
             UsernamePasswordAuthenticator(username, password),
-            AsyncHttpClient(),
+            asyncHttpClient,
             objectMapper.reader(),
             objectMapper.writer())
 }

--- a/examples/src/main/kotlin/io/aexp/bucketlist/examples/prfileoccurrences/ExportPrFileOccurrencesData.kt
+++ b/examples/src/main/kotlin/io/aexp/bucketlist/examples/prfileoccurrences/ExportPrFileOccurrencesData.kt
@@ -1,0 +1,115 @@
+package io.aexp.bucketlist.examples.prfileoccurrences
+
+import com.google.common.collect.HashMultiset
+import com.google.common.collect.Multiset
+import com.google.common.collect.Multisets
+import com.opencsv.CSVWriter
+import io.aexp.bucketlist.BucketListClient
+import io.aexp.bucketlist.data.PullRequestState
+import io.aexp.bucketlist.examples.getBitBucketClient
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import rx.Observable
+import rx.schedulers.Schedulers
+import java.io.FileWriter
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.util.ArrayList
+
+object ExportPrFileOccurrencesData {
+    val logger: Logger = LoggerFactory.getLogger(javaClass)
+
+    @JvmStatic fun main(args: Array<String>) {
+        if (args.size != 7) {
+            System.err!!.println("Must have 7 arguments: <config file> <project key> <repo slug> <branch filter substring> <output file> <start date> <end date>")
+            System.exit(1)
+        }
+
+        val configPath = Paths.get(args[0])
+
+        val client = getBitBucketClient(configPath)
+        val projectKey = args[1]
+        val repoSlug = args[2]
+        val branchFilterSubstring = args[3]
+        val outputCsvPath = Paths.get(args[4])
+        val startDate = ZonedDateTime.of(LocalDateTime.of(LocalDate.parse(args[5]), LocalTime.MIDNIGHT), ZoneId.of("UTC"))
+        val endDate = ZonedDateTime.of(LocalDateTime.of(LocalDate.parse(args[6]), LocalTime.MIDNIGHT), ZoneId.of("UTC"))
+
+        countFileOccurrencesInPrs(client, projectKey, repoSlug, branchFilterSubstring, outputCsvPath, startDate, endDate);
+    }
+
+    private fun countFileOccurrencesInPrs(client: BucketListClient, projectKey: String, repoSlug: String,
+                                          branchFilterSubstring: String, outputCsvPath: Path, startDate: ZonedDateTime,
+                                          endDate: ZonedDateTime) {
+
+        val fileOccurrences = getFlattenedCountOfFilesFromPrs(client, projectKey, repoSlug, branchFilterSubstring, startDate, endDate)
+                .toBlocking()
+                .first()
+
+        printToCsv(outputCsvPath, fileOccurrences)
+        System.exit(0)
+    }
+
+    private fun getFilesChangedInPr(prId: Long, client: BucketListClient, projectKey: String, repoSlug: String):
+            Observable<String> {
+        logger.debug("Fetching diff for PR " + prId);
+
+        return client.getPrDiff(projectKey, repoSlug, prId, 0, false, false)
+                .first()
+                .flatMap { diffResponse ->
+                    logger.debug("Parsing PR for files changed");
+                    Observable.from(diffResponse.diffs)
+                            .filter { diff ->
+                                diff.source != null && diff.destination != null &&
+                                        diff.source!!.fullPath == diff.destination!!.fullPath
+                            }
+                            .map { diff -> diff.source!!.fullPath }
+                }
+    }
+
+    private fun getFlattenedCountOfFilesFromPrs(client: BucketListClient, projectKey: String, repoSlug: String,
+                                                branchFilterSubstring: String, startDate: ZonedDateTime, endDate: ZonedDateTime):
+            Observable<Multiset<String>> {
+        // Get all of the PRs associated with the projectKey + repoSlug, and filter for those within the specified
+        // startDate and endDate range. Then filter for only those that contain the branchFilterSubstring in the source
+        // branch name. Extract the ids into a list.
+        val prIds = client.getPrs(projectKey, repoSlug, PullRequestState.MERGED)
+                .flatMap { prs -> Observable.from(prs.values) }
+                .filter { pr ->
+                    pr.createdAt.isBefore(endDate) && !(pr.closed && pr.updatedAt.isBefore(startDate))
+                }
+                .filter { pr -> pr.fromRef.id.contains(branchFilterSubstring, true) }
+                .map { pr -> pr.id }
+
+        val multiset: Multiset<String> = HashMultiset.create<String>()
+
+        // For each of the PRs, get list of files that have been changed. Then reduce them into one Multiset to get an
+        // occurrence count across PRs
+        return prIds.flatMap({ prId ->
+            getFilesChangedInPr(prId, client, projectKey, repoSlug)
+        })
+                .observeOn(Schedulers.trampoline())
+                .reduce(multiset, { set, filePath: String ->
+                    set.add(filePath)
+                    set
+                })
+    }
+
+    private fun printToCsv(outputCsvPath: Path, filesWithCounts: Multiset<String>) {
+        val outputCsvFile = outputCsvPath.toFile()
+        CSVWriter(FileWriter(outputCsvFile)).use { writer ->
+            for (file in Multisets.copyHighestCountFirst(filesWithCounts).elementSet()) {
+                val row = ArrayList<String>()
+                row.add(file)
+                row.add(filesWithCounts.count(file).toString())
+                writer.writeNext(row.toArray(arrayOfNulls<String>(0)))
+            }
+        }
+        logger.info("Done writing CSV file")
+    }
+}

--- a/examples/src/main/kotlin/io/aexp/bucketlist/examples/prfileoccurrences/ExportPrFileOccurrencesData.kt
+++ b/examples/src/main/kotlin/io/aexp/bucketlist/examples/prfileoccurrences/ExportPrFileOccurrencesData.kt
@@ -5,6 +5,7 @@ import com.google.common.collect.Multiset
 import com.google.common.collect.Multisets
 import com.opencsv.CSVWriter
 import io.aexp.bucketlist.BucketListClient
+import io.aexp.bucketlist.data.CommentMode
 import io.aexp.bucketlist.data.PullRequestState
 import io.aexp.bucketlist.examples.getBitBucketClient
 import org.slf4j.Logger
@@ -92,7 +93,7 @@ object ExportPrFileOccurrencesData {
             Observable<String> {
         logger.debug("Fetching diff for PR " + prId);
 
-        return client.getPrDiff(projectKey, repoSlug, prId, 0, "ignore-all", false)
+        return client.getPrDiff(projectKey, repoSlug, prId, 0, "ignore-all", CommentMode.WithoutComments)
                 .flatMap { diffResponse ->
                     logger.debug("Parsing PR for files changed");
                     // Filter diffs with Null sources or destinations as that indicates a new or deleted file. Then

--- a/examples/src/main/kotlin/io/aexp/bucketlist/examples/prfileoccurrences/ExportPrFileOccurrencesData.kt
+++ b/examples/src/main/kotlin/io/aexp/bucketlist/examples/prfileoccurrences/ExportPrFileOccurrencesData.kt
@@ -27,8 +27,7 @@ import java.util.ArrayList
  *
  * We wanted to better inform our decision of when to refactor different classes by identifying which were more highly
  * correlated with bugs. So this determines in how many PRs across a given date range was each file changed. With the
- * 'branch filter substring', we were able to reduce the set to only ones including our 'bugfix' prefix. The results are
- * written
+ * 'branch filter substring', we were able to reduce the set to only ones including our 'bugfix' prefix.
  *
  * This example is purely a data generator because we found that inspecting the top of the resulting list provided ample
  * insights to which files experienced the most churn with bugfixes.
@@ -118,7 +117,7 @@ object ExportPrFileOccurrencesData {
                 .filter { pr -> pr.fromRef.id.contains(branchFilterSubstring, true) }
                 .map { pr -> pr.id }
 
-        val multiset: Multiset<String> = HashMultiset.create<String>()
+        val multiset: Multiset<String> = HashMultiset.create()
 
         // For each of the PRs, get list of files that have been changed. Then reduce them into one Multiset to get an
         // occurrence count across PRs

--- a/examples/src/main/kotlin/io/aexp/bucketlist/examples/prfileoccurrences/ExportPrFileOccurrencesData.kt
+++ b/examples/src/main/kotlin/io/aexp/bucketlist/examples/prfileoccurrences/ExportPrFileOccurrencesData.kt
@@ -97,7 +97,7 @@ object ExportPrFileOccurrencesData {
             Observable<String> {
         logger.debug("Fetching diff for PR " + prId);
 
-        return client.getPrDiff(projectKey, repoSlug, prId, 0, WhitespaceMode.IgnoreAll, CommentMode.WithoutComments)
+        return client.getPrDiff(projectKey, repoSlug, prId, 0, WhitespaceMode.IGNORE_ALL, CommentMode.WITHOUT_COMMENTS)
                 .flatMap { diffResponse ->
                     logger.debug("Parsing PR for files changed");
                     // Filter diffs with Null sources or destinations as that indicates a new or deleted file. Then

--- a/examples/src/main/kotlin/io/aexp/bucketlist/examples/prfileoccurrences/ExportPrFileOccurrencesData.kt
+++ b/examples/src/main/kotlin/io/aexp/bucketlist/examples/prfileoccurrences/ExportPrFileOccurrencesData.kt
@@ -29,8 +29,8 @@ import java.util.ArrayList
  * correlated with bugs. So this determines in how many PRs across a given date range was each file changed. With the
  * 'branch filter substring', we were able to reduce the set to only ones including our 'bugfix' prefix.
  *
- * This example is purely a data generator because we found that inspecting the top of the resulting list provided ample
- * insights to which files experienced the most churn with bugfixes.
+ * For this example we found that inspecting the top of the resulting list provided ample insights to which files
+ * experienced the most churn with bugfixes, and thus there is no graphing component.
  *
  * Usages:
  * - make a properties file containing 'username', 'password', and 'url' info for your Bitbucket-Server instance
@@ -51,9 +51,19 @@ object ExportPrFileOccurrencesData {
         val projectKey = args[1]
         val repoSlug = args[2]
         val branchFilterSubstring = args[3]
+
         val startDate = ZonedDateTime.of(LocalDateTime.of(LocalDate.parse(args[4]), LocalTime.MIDNIGHT), ZoneId.of("UTC"))
+        // Make endDate inclusive by adding a day
         val endDate = ZonedDateTime.of(LocalDateTime.of(LocalDate.parse(args[5]), LocalTime.MIDNIGHT), ZoneId.of("UTC"))
+                .plusDays(1)
+
+        if (startDate.isAfter(endDate)) {
+            System.err!!.println("Start date must be before end date")
+            System.exit(1);
+        }
+
         val outputCsvPath = Paths.get(args[6])
+
 
         countFileOccurrencesInPrs(client, projectKey, repoSlug, branchFilterSubstring, outputCsvPath, startDate, endDate);
     }
@@ -83,7 +93,6 @@ object ExportPrFileOccurrencesData {
         logger.debug("Fetching diff for PR " + prId);
 
         return client.getPrDiff(projectKey, repoSlug, prId, 0, "ignore-all", false)
-                .first()
                 .flatMap { diffResponse ->
                     logger.debug("Parsing PR for files changed");
                     // Filter diffs with Null sources or destinations as that indicates a new or deleted file. Then

--- a/examples/src/main/kotlin/io/aexp/bucketlist/examples/prfileoccurrences/ExportPrFileOccurrencesData.kt
+++ b/examples/src/main/kotlin/io/aexp/bucketlist/examples/prfileoccurrences/ExportPrFileOccurrencesData.kt
@@ -5,6 +5,7 @@ import com.google.common.collect.Multiset
 import com.google.common.collect.Multisets
 import com.opencsv.CSVWriter
 import io.aexp.bucketlist.BucketListClient
+import io.aexp.bucketlist.WhitespaceMode
 import io.aexp.bucketlist.data.CommentMode
 import io.aexp.bucketlist.data.PullRequestState
 import io.aexp.bucketlist.examples.getBitBucketClient
@@ -93,7 +94,7 @@ object ExportPrFileOccurrencesData {
             Observable<String> {
         logger.debug("Fetching diff for PR " + prId);
 
-        return client.getPrDiff(projectKey, repoSlug, prId, 0, "ignore-all", CommentMode.WithoutComments)
+        return client.getPrDiff(projectKey, repoSlug, prId, 0, WhitespaceMode.IgnoreAll, CommentMode.WithoutComments)
                 .flatMap { diffResponse ->
                     logger.debug("Parsing PR for files changed");
                     // Filter diffs with Null sources or destinations as that indicates a new or deleted file. Then

--- a/examples/src/main/kotlin/io/aexp/bucketlist/examples/prfileoccurrences/ExportPrFileOccurrencesData.kt
+++ b/examples/src/main/kotlin/io/aexp/bucketlist/examples/prfileoccurrences/ExportPrFileOccurrencesData.kt
@@ -82,7 +82,7 @@ object ExportPrFileOccurrencesData {
             Observable<String> {
         logger.debug("Fetching diff for PR " + prId);
 
-        return client.getPrDiff(projectKey, repoSlug, prId, 0, false, false)
+        return client.getPrDiff(projectKey, repoSlug, prId, 0, "ignore-all", false)
                 .first()
                 .flatMap { diffResponse ->
                     logger.debug("Parsing PR for files changed");


### PR DESCRIPTION
Adding support for bitbucket server's pull-request diff endpoint. Additionally, this includes a new example which takes advantage of the endpoint to compute occurrences of files being modified across PRs to help identify churn as well as potential sources of bugs.
