### PR TITLE
Feature/raw lifetime data

### DIFF
--- a/examples/src/main/kotlin/io/aexp/bucketlist/examples/prlifetime/ExportPrLifetimeData.kt
+++ b/examples/src/main/kotlin/io/aexp/bucketlist/examples/prlifetime/ExportPrLifetimeData.kt
@@ -149,25 +149,6 @@ object ExportPrLifetimeData {
     data class WeekStats(val mondayOfWeek: LocalDate, val stats: DescriptiveStatistics = DescriptiveStatistics()) {}
 
     /**
-     * Wrapper to bundle a PR with its activity
-     */
-    data class PrSummary(val pr: PullRequest, val activity: List<PullRequestActivity>) {
-        val durationSinceStart: Duration
-            get() = Duration.between(activity.first().createdAt, activity.last().createdAt)
-
-        val durationSinceLastPRCommitPushed: Duration
-            get() {
-                var mergeTime = activity.filter({ event -> event.action == "MERGED" }).last().createdAt
-                var lastCommitTime = activity.filter({ event -> event.action == "RESCOPED" || event.action == "OPENED" }).last().createdAt
-
-                return Duration.between(lastCommitTime, mergeTime)
-            }
-
-        val mondayOfWeekOfStart: LocalDate
-            get() = pr.createdAt.toLocalDate().with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
-    }
-
-    /**
      * Write the populated DataSource into tsv for later graphing
      */
     fun writeData(ds: DataSource, path: Path) {

--- a/examples/src/main/kotlin/io/aexp/bucketlist/examples/prlifetime/ExportRawPrLifetimeData.kt
+++ b/examples/src/main/kotlin/io/aexp/bucketlist/examples/prlifetime/ExportRawPrLifetimeData.kt
@@ -57,7 +57,7 @@ object ExportRawPrLifetimeData {
                 .toBlocking()
                 .first()
 
-        printBetterCsv(outputCsvPath, prSummaries)
+        writeToCSV(outputCsvPath, prSummaries)
         System.exit(0)
     }
 
@@ -89,7 +89,7 @@ object ExportRawPrLifetimeData {
     /**
      * Writes creation date and durations for PrSummaries
      */
-    private fun printBetterCsv(outputCsvPath: Path, prSummaries: List<PrSummary>) {
+    private fun writeToCSV(outputCsvPath: Path, prSummaries: List<PrSummary>) {
         val outputCsvFile = outputCsvPath.toFile()
         CSVWriter(FileWriter(outputCsvFile)).use { writer ->
             val header = ArrayList<String>()
@@ -100,8 +100,7 @@ object ExportRawPrLifetimeData {
 
             for (prSummary in prSummaries) {
                 val row = ArrayList<String>()
-                val pr = prSummary.pr
-                row.add(pr.createdAt.toString())
+                row.add(prSummary.pr.createdAt.toString())
 
                 val hoursSinceStart = getFractionalHoursFromDuration(prSummary.durationSinceStart)
                 row.add(hoursSinceStart.toString())

--- a/examples/src/main/kotlin/io/aexp/bucketlist/examples/prlifetime/ExportRawPrLifetimeData.kt
+++ b/examples/src/main/kotlin/io/aexp/bucketlist/examples/prlifetime/ExportRawPrLifetimeData.kt
@@ -1,0 +1,100 @@
+package io.aexp.bucketlist.examples.prlifetime
+
+import com.opencsv.CSVWriter
+import io.aexp.bucketlist.BucketListClient
+import io.aexp.bucketlist.data.Order
+import io.aexp.bucketlist.data.PullRequestState
+import io.aexp.bucketlist.examples.getBitBucketClient
+import rx.Observable
+import rx.schedulers.Schedulers
+import java.io.FileWriter
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.time.Duration
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.util.ArrayList
+import java.util.concurrent.TimeUnit
+
+
+object ExportRawPrLifetimeData {
+
+    private const val ARGUMENTS_COUNT = 6
+
+    @JvmStatic fun main(args: Array<String>) {
+        if (args.size != ExportRawPrLifetimeData.ARGUMENTS_COUNT) {
+            System.err!!.println(String.format("Must have %d arguments: <config file> <project key> <repo slug> <output file> <start date> <end date>", ExportRawPrLifetimeData.ARGUMENTS_COUNT))
+            System.exit(1)
+        }
+
+        val configPath = Paths.get(args[0])
+
+        val client = getBitBucketClient(configPath)
+        val projectKey = args[1]
+        val repoSlug = args[2]
+        val outputCsvPath = Paths.get(args[3])
+
+        val startDate = ZonedDateTime.of(LocalDateTime.of(LocalDate.parse(args[4]), LocalTime.MIDNIGHT), ZoneId.of("UTC"))
+        val endDate = ZonedDateTime.of(LocalDateTime.of(LocalDate.parse(args[5]), LocalTime.MIDNIGHT), ZoneId.of("UTC"))
+
+        val prSummaries = getPrSummaries(client, projectKey, repoSlug, startDate, endDate)
+                .toSortedList({ prSummary1, prSummary2 -> prSummary1.pr.createdAt.compareTo(prSummary2.pr.createdAt) })
+                .toBlocking()
+                .first()
+
+        printBetterCsv(outputCsvPath, prSummaries)
+        System.exit(0)
+    }
+
+    private fun getPrSummaries(client: BucketListClient, projKey: String, repoSlug: String, startDate: ZonedDateTime,
+                               endDate: ZonedDateTime) : Observable<PrSummary> {
+        return client.getPrs(projKey, repoSlug, PullRequestState.MERGED, Order.OLDEST)
+                .observeOn(Schedulers.io())
+                // flatten pages into one stream of prs
+                .flatMap({ prs -> Observable.from(prs.values) })
+                .filter({ pr ->
+                    // Don't bother getting activity for any PRs that were created after the end date
+                    // Don't bother getting activity for any PRs that are closed, where the last update was before the start date.
+                    pr.createdAt.isBefore(endDate) && !(pr.closed && pr.updatedAt.isBefore(startDate))
+                })
+                .flatMap({ pr ->
+                    // gather all activity for each pr into a PrSummary
+                    client.getPrActivity(projKey, repoSlug, pr.id)
+                            .flatMap({ page -> Observable.from(page.values) })
+                            .toSortedList({ a1, a2 -> a1.createdAt.compareTo(a2.createdAt) })
+                            .map({ list -> PrSummary(pr, list) })
+                })
+    }
+
+    private fun printBetterCsv(outputCsvPath: Path, prSummaries: List<PrSummary>) {
+        val outputCsvFile = outputCsvPath.toFile()
+        CSVWriter(FileWriter(outputCsvFile)).use { writer ->
+            val header = ArrayList<String>()
+            header.add("Created At")
+            header.add("Duration Since Start (hours)")
+            header.add("Duration Since Last Push (hours)")
+            writer.writeNext(header.toArray(arrayOfNulls<String>(0)))
+
+            for (prSummary in prSummaries) {
+                val row = ArrayList<String>()
+                val pr = prSummary.pr
+                row.add(pr.createdAt.toString())
+
+                val hoursSinceStart = getFractionalHoursFromDuration(prSummary.durationSinceStart)
+                row.add(hoursSinceStart.toString())
+
+                val hoursSinceLastPush = getFractionalHoursFromDuration(prSummary.durationSinceLastPRCommitPushed)
+                row.add(hoursSinceLastPush.toString())
+
+                writer.writeNext(row.toArray(arrayOfNulls<String>(0)))
+            }
+        }
+    }
+
+    private fun getFractionalHoursFromDuration(duration: Duration) : Double {
+        return duration.toMillis().toDouble() / TimeUnit.HOURS.toMillis(1)
+    }
+}

--- a/examples/src/main/kotlin/io/aexp/bucketlist/examples/prlifetime/PrSummary.kt
+++ b/examples/src/main/kotlin/io/aexp/bucketlist/examples/prlifetime/PrSummary.kt
@@ -1,0 +1,25 @@
+package io.aexp.bucketlist.examples.prlifetime
+
+import io.aexp.bucketlist.data.PullRequest
+import io.aexp.bucketlist.data.PullRequestActivity
+import java.time.DayOfWeek
+import java.time.Duration
+import java.time.LocalDate
+import java.time.temporal.TemporalAdjusters
+
+
+data class PrSummary(val pr: PullRequest, val activity: List<PullRequestActivity>) {
+    val durationSinceStart: Duration
+        get() = Duration.between(activity.first().createdAt, activity.last().createdAt)
+
+    val durationSinceLastPRCommitPushed: Duration
+        get() {
+            var mergeTime = activity.filter({ event -> event.action == "MERGED" }).last().createdAt
+            var lastCommitTime = activity.filter({ event -> event.action == "RESCOPED" || event.action == "OPENED" }).last().createdAt
+
+            return Duration.between(lastCommitTime, mergeTime)
+        }
+
+    val mondayOfWeekOfStart: LocalDate
+        get() = pr.createdAt.toLocalDate().with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+}


### PR DESCRIPTION
Adding ExportRawPrLifetimeData which skips aggregating data on a weekly basis, and instead provides both durations in a CSV for further analysis.
